### PR TITLE
Increment track views

### DIFF
--- a/client/src/containers/track-card.tsx
+++ b/client/src/containers/track-card.tsx
@@ -1,9 +1,25 @@
-import React from "react";
 import styled from "@emotion/styled";
+import React from "react";
+import { Link } from "react-router-dom";
+import { gql } from "../__generated__";
+import { Track } from "../__generated__/graphql";
 import { colors, mq } from "../styles";
 import { humanReadableTimeFromSeconds } from "../utils/helpers";
-import { Track } from "../__generated__/graphql";
-import { Link } from "react-router-dom";
+import { useMutation } from "@apollo/client";
+
+const INCREMENT_TRACK_VIEWS = gql(`
+  mutation IncrementTrackViews($incrementTrackViewsId: ID!) {
+    incrementTrackViews(id: $incrementTrackViewsId) {
+      code
+      success
+      message
+      track {
+        id
+        numberOfViews
+      }
+    }
+  }
+`);
 
 /**
  * Track Card component renders basic info in a card format
@@ -12,8 +28,18 @@ import { Link } from "react-router-dom";
 const TrackCard: React.FC<{ track: Track }> = ({ track }) => {
   const { title, thumbnail, author, length, modulesCount, id } = track;
 
+  const [incrementTrackViews, { loading, error, data }] = useMutation(
+    INCREMENT_TRACK_VIEWS,
+    {
+      variables: { incrementTrackViewsId: id },
+      onCompleted: (data) => {
+        console.log(data);
+      },
+    }
+  );
+
   return (
-    <CardContainer to={`track/${id}`}>
+    <CardContainer to={`track/${id}`} onClick={() => incrementTrackViews()}>
       <CardContent>
         <CardImageContainer>
           <CardImage src={thumbnail || ""} alt={title} />

--- a/server/src/dataSources/track-api.ts
+++ b/server/src/dataSources/track-api.ts
@@ -19,4 +19,8 @@ export class TrackAPI extends RESTDataSource {
   getTrackModules(trackId: string) {
     return this.get<ModuleModel[]>(`/track/${trackId}/modules`);
   }
+
+  incrementTrackViews(trackId: string) {
+    return this.patch<TrackModel>(`track/${trackId}/numberOfViews`);
+  }
 }

--- a/server/src/resolvers.ts
+++ b/server/src/resolvers.ts
@@ -10,6 +10,28 @@ export const resolvers: Resolvers = {
     },
   },
 
+  Mutation: {
+    incrementTrackViews: async (_, { id }, { dataSources }) => {
+      try {
+        const track = await dataSources.trackAPI.incrementTrackViews(id);
+
+        return {
+          code: 200,
+          success: true,
+          message: `Successfully incremented number of views for track ${id}`,
+          track,
+        };
+      } catch (err) {
+        return {
+          code: err.extensions.response.status,
+          success: false,
+          message: err.extensions.response.body,
+          track: null,
+        };
+      }
+    },
+  },
+
   Track: {
     author: ({ authorId }, _, { dataSources }) => {
       return dataSources.trackAPI.getAuthor(authorId);

--- a/server/src/schema.ts
+++ b/server/src/schema.ts
@@ -8,6 +8,17 @@ export const typeDefs = gql`
     track(id: ID!): Track
   }
 
+  type Mutation {
+    incrementTrackViews(id: ID!): IncrementTrackViewsResponse!
+  }
+
+  type IncrementTrackViewsResponse {
+    code: Int!
+    success: Boolean!
+    message: String!
+    track: Track
+  }
+
   "A track is a group of Modules that teaches about a specific topic"
   type Track {
     id: ID!


### PR DESCRIPTION
Added mutation to the schema and resolvers to increment the number of times a track has been viewed.
Now when a user clicks on the views, it will increment the number of views.